### PR TITLE
Update SwaggerRouteMetadataExtensions.cs

### DIFF
--- a/Nancy.Metadata.Swagger/Fluent/SwaggerRouteMetadataExtensions.cs
+++ b/Nancy.Metadata.Swagger/Fluent/SwaggerRouteMetadataExtensions.cs
@@ -9,7 +9,7 @@ namespace Nancy.Metadata.Swagger.Fluent
         public static SwaggerRouteMetadata With(this SwaggerRouteMetadata routeMetadata,
             Func<SwaggerEndpointInfo, SwaggerEndpointInfo> info)
         {
-            routeMetadata.Info = info(new SwaggerEndpointInfo());
+            routeMetadata.Info = info(routeMetadata.Info ?? new SwaggerEndpointInfo());
 
             return routeMetadata;
         }


### PR DESCRIPTION
Afais you can't add several parameters because on every "with" call the old SwaggerEndpointInfo is overwritten
