### PR TITLE
operationId support added

### DIFF
--- a/Nancy.Metadata.Swagger/Fluent/SwaggerEndpointInfoExtensions.cs
+++ b/Nancy.Metadata.Swagger/Fluent/SwaggerEndpointInfoExtensions.cs
@@ -5,6 +5,7 @@ using Nancy.Metadata.Swagger.Core;
 using Nancy.Metadata.Swagger.Model;
 using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Schema.Generation;
+using System.Linq;
 
 namespace Nancy.Metadata.Swagger.Fluent
 {
@@ -81,6 +82,20 @@ namespace Nancy.Metadata.Swagger.Fluent
             });
 
             return endpointInfo;
+        }
+
+        public static SwaggerEndpointInfo WithTags(this SwaggerEndpointInfo info, IEnumerable<string> tags)
+        {
+            info.Tags = tags.ToArray();
+
+            return info;
+        }
+
+        public static SwaggerEndpointInfo WithMethodName(this SwaggerEndpointInfo info, string name)
+        {
+            info.MethodName = name;
+
+            return info;
         }
 
         public static SwaggerEndpointInfo WithDescription(this SwaggerEndpointInfo endpointInfo, string description, params string[] tags)

--- a/Nancy.Metadata.Swagger/Model/SwaggerEndpointInfo.cs
+++ b/Nancy.Metadata.Swagger/Model/SwaggerEndpointInfo.cs
@@ -14,6 +14,9 @@ namespace Nancy.Metadata.Swagger.Model
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonProperty("operationId")]
+        public string MethodName { get; set; }
+
         [JsonProperty("responses")]
         public Dictionary<string, SwaggerResponseInfo> ResponseInfos { get; set; }
 


### PR DESCRIPTION
That's property of endpoint which primary usage is method name in automatically code-generated client method names (like in [this](https://github.com/swagger-api/swagger-js) one)